### PR TITLE
Set best=1 in dnf.conf

### DIFF
--- a/src/main/java/io/kojan/mbici/tasks/Mock.java
+++ b/src/main/java/io/kojan/mbici/tasks/Mock.java
@@ -91,6 +91,7 @@ class Mock {
             bw.write("assumeyes=1\n");
             bw.write("install_weak_deps=" + (installWeakDeps ? 1 : 0) + "\n");
             bw.write("metadata_expire=-1\n");
+            bw.write("best=1\n");
 
             int priority = 0;
             for (Path repoPath : context.getDependencyArtifacts(ArtifactType.REPO)) {


### PR DESCRIPTION
This ensures DNF always installs the best available version of a package. If the newest version cannot be installed due to dependency issues, DNF will fail instead of falling back to an older version.

Without this setting, DNF may silently install outdated packages, leading to inconsistent or unexpected behavior.

Closes #35