### PR TITLE
Add rpm-build to protected packages in mock

### DIFF
--- a/src/main/java/io/kojan/mbici/tasks/Mock.java
+++ b/src/main/java/io/kojan/mbici/tasks/Mock.java
@@ -92,6 +92,7 @@ class Mock {
             bw.write("install_weak_deps=" + (installWeakDeps ? 1 : 0) + "\n");
             bw.write("metadata_expire=-1\n");
             bw.write("best=1\n");
+            bw.write("protected_packages=rpm-build\n");
 
             int priority = 0;
             for (Path repoPath : context.getDependencyArtifacts(ArtifactType.REPO)) {


### PR DESCRIPTION
Sometimes dnf will try to remove it when installing dependencies.

Related #35