### PR TITLE
Disable RPM payload compression

### DIFF
--- a/src/main/java/io/kojan/mbici/tasks/Mock.java
+++ b/src/main/java/io/kojan/mbici/tasks/Mock.java
@@ -73,6 +73,8 @@ class Mock {
                                 + authorizedSshKey
                                 + "'\n");
             }
+            bw.write("config_opts['macros']['%_source_payload'] = 'w.ufdio'\n");
+            bw.write("config_opts['macros']['%_binary_payload'] = 'w.ufdio'\n");
             for (var macro : macros.entrySet()) {
                 bw.write(
                         "config_opts['macros']['%"


### PR DESCRIPTION
SRPMs primarily contain upstream tarballs, which are already compressed. Since Javadocs have been dropped from Fedora, binary RPMs now mostly consist of JAR files, which are also compressed.

As a result, RPM payload compression offers little to no space savings on average, while unnecessarily consuming CPU time during compression and decompression.

Closes #36