### PR TITLE
Decouple test execution from build workflow

### DIFF
--- a/src/main/java/io/kojan/mbici/execute/TaskHandlerFactoryImpl.java
+++ b/src/main/java/io/kojan/mbici/execute/TaskHandlerFactoryImpl.java
@@ -30,7 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-class TaskHandlerFactoryImpl implements TaskHandlerFactory {
+public class TaskHandlerFactoryImpl implements TaskHandlerFactory {
     private final Map<String, Function<Task, ? extends AbstractTaskHandler>> registry =
             new LinkedHashMap<>();
     private final CacheManager cacheManager;

--- a/src/main/java/io/kojan/mbici/generate/GenerateCommand.java
+++ b/src/main/java/io/kojan/mbici/generate/GenerateCommand.java
@@ -56,8 +56,6 @@ public class GenerateCommand extends AbstractCommand {
             description = "Path where generated Workflow should be written.")
     private Path workflowPath;
 
-    private Path testPlatformPath;
-
     public Path getPlanPath() {
         return planPath;
     }
@@ -90,25 +88,14 @@ public class GenerateCommand extends AbstractCommand {
         this.workflowPath = workflowPath;
     }
 
-    public Path getTestPlatformPath() {
-        return testPlatformPath;
-    }
-
-    public void setTestPlatformPath(Path testPlatformPath) {
-        this.testPlatformPath = testPlatformPath;
-    }
-
     @Override
     public Integer call() throws Exception {
         Plan plan = Plan.readFromXML(planPath);
         Platform platform = Platform.readFromXML(platformPath);
-        Platform testPlatform =
-                testPlatformPath == null ? null : Platform.readFromXML(testPlatformPath);
         Subject subject = Subject.readFromXML(subjectPath);
 
         WorkflowFactory wff = new WorkflowFactory();
-        Workflow wfd =
-                wff.createFromPlan(platform, testPlatform, plan, subject, testPlatform != null);
+        Workflow wfd = wff.createFromPlan(platform, plan, subject);
         wfd.writeToXML(workflowPath);
 
         return 0;

--- a/src/main/java/io/kojan/mbici/generate/TaskFactory.java
+++ b/src/main/java/io/kojan/mbici/generate/TaskFactory.java
@@ -28,6 +28,7 @@ import io.kojan.mbici.tasks.SrpmTaskHandler;
 import io.kojan.workflow.model.Task;
 import io.kojan.workflow.model.TaskBuilder;
 import io.kojan.workflow.model.WorkflowBuilder;
+import java.nio.file.Path;
 import java.util.List;
 
 /// @author Mikolaj Izdebski
@@ -135,12 +136,12 @@ class TaskFactory {
         return taskDescriptor;
     }
 
-    public Task createProvisionTask(Task platformRepo, Task composeRepo) {
+    public Task createProvisionTask(Task platformRepo, Path composeRepoDir) {
         TaskBuilder task = new TaskBuilder();
         task.setId("provision");
         task.setHandler(PROVISION_HANDLER);
-        task.addDependency(composeRepo.getId());
         task.addDependency(platformRepo.getId());
+        task.addParameter("compose", composeRepoDir.toString());
         Task taskDescriptor = task.build();
         workflowBuilder.addTask(taskDescriptor);
         return taskDescriptor;


### PR DESCRIPTION
Previously, running tests always triggered the build workflow first. This meant tests could not be executed independently and added unnecessary overhead when only the test stage was needed.

Now, tests run directly on the existing build artifacts. This avoids redundant rebuilding, reduces execution time, and makes the test workflow simpler and more predictable while keeping the build workflow unchanged.

Closes #39