### PR TITLE
Simplify guest SSH setup with Unix socket

### DIFF
--- a/src/main/java/io/kojan/mbici/tasks/Mock.java
+++ b/src/main/java/io/kojan/mbici/tasks/Mock.java
@@ -37,7 +37,6 @@ class Mock {
     int timeout = MOCK_TIMEOUT;
     boolean installWeakDeps = false;
     Set<Path> bindMounts = new LinkedHashSet<>();
-    Set<String> authorizedSshKeys = new LinkedHashSet<>();
     final Map<String, Path> repos = new LinkedHashMap<>();
 
     public void run(TaskExecutionContext context, String... mockArgs) throws TaskTermination {
@@ -69,12 +68,6 @@ class Mock {
                                 + "', '"
                                 + bindMount
                                 + "'))\n");
-            }
-            for (String authorizedSshKey : authorizedSshKeys) {
-                bw.write(
-                        "config_opts['files']['root/.ssh/authorized_keys'] = '"
-                                + authorizedSshKey
-                                + "'\n");
             }
             bw.write("config_opts['macros']['%_source_payload'] = 'w.ufdio'\n");
             bw.write("config_opts['macros']['%_binary_payload'] = 'w.ufdio'\n");

--- a/src/main/java/io/kojan/mbici/workspace/AbstractTmtCommand.java
+++ b/src/main/java/io/kojan/mbici/workspace/AbstractTmtCommand.java
@@ -16,7 +16,6 @@
 package io.kojan.mbici.workspace;
 
 import io.kojan.mbici.AbstractCommand;
-import io.kojan.mbici.tasks.Guest;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -100,13 +99,23 @@ public abstract class AbstractTmtCommand extends AbstractCommand {
             cmd.add("--how");
             cmd.add("connect");
             cmd.add("--guest");
-            cmd.add(Guest.SSH_HOST);
-            cmd.add("--port");
-            cmd.add(Guest.SSH_PORT);
+            cmd.add("dummy");
             cmd.add("--user");
-            cmd.add(Guest.SSH_USER);
-            cmd.add("--key");
-            cmd.add(Guest.SSH_PRIV_KEY);
+            cmd.add("root");
+            cmd.add("--ssh-option");
+            cmd.add("ProxyCommand=socat - UNIX-CONNECT:" + shell.getSocketPath());
+            cmd.add("--ssh-option");
+            cmd.add("PreferredAuthentications=password");
+            cmd.add("--ssh-option");
+            cmd.add("PubkeyAuthentication=no");
+            cmd.add("--ssh-option");
+            cmd.add("KbdInteractiveAuthentication=no");
+            cmd.add("--ssh-option");
+            cmd.add("GSSAPIAuthentication=no");
+            cmd.add("--ssh-option");
+            cmd.add("UserKnownHostsFile=/dev/null");
+            cmd.add("--ssh-option");
+            cmd.add("StrictHostKeyChecking=no");
             cmd.add("-vvv");
         } else {
             cmd.add("provision");

--- a/src/main/java/io/kojan/mbici/workspace/ShellCommand.java
+++ b/src/main/java/io/kojan/mbici/workspace/ShellCommand.java
@@ -121,6 +121,10 @@ public class ShellCommand extends AbstractCommand {
         getGuest().runSshClient("kill $(cat /tmp/sshd.pid)");
     }
 
+    public Path getSocketPath() {
+        return getGuest().getSocketPath();
+    }
+
     @Override
     public Integer call() throws Exception {
         Integer ret = provision();


### PR DESCRIPTION
The previous approach relied on host networking and user SSH keys, which introduced unnecessary configuration, key management, and external dependencies.

By switching to a Unix domain socket with a minimal in-chroot SSH server, the setup becomes much simpler: no ports to allocate, no keys to distribute, and no reliance on host networking. The guest can now be started and connected in a fully self-contained way with fewer moving parts.

Closes #40