### PR TITLE
Assign unique IDs to provision tasks

### DIFF
--- a/src/main/java/io/kojan/mbici/generate/TaskFactory.java
+++ b/src/main/java/io/kojan/mbici/generate/TaskFactory.java
@@ -136,9 +136,10 @@ class TaskFactory {
         return taskDescriptor;
     }
 
-    public Task createProvisionTask(Task platformRepo, Path composeRepoDir) {
+    public Task createProvisionTask(
+            String provisionTaskId, Task platformRepo, Path composeRepoDir) {
         TaskBuilder task = new TaskBuilder();
-        task.setId("provision");
+        task.setId("provision-" + provisionTaskId);
         task.setHandler(PROVISION_HANDLER);
         task.addDependency(platformRepo.getId());
         task.addParameter("compose", composeRepoDir.toString());

--- a/src/main/java/io/kojan/mbici/generate/WorkflowFactory.java
+++ b/src/main/java/io/kojan/mbici/generate/WorkflowFactory.java
@@ -88,14 +88,15 @@ public class WorkflowFactory {
         return workflowBuilder.build();
     }
 
-    public Workflow createTestWorkflow(Platform testPlatform, Path composeRepoDir) {
+    public Workflow createTestWorkflow(
+            String provisionTaskId, Platform testPlatform, Path composeRepoDir) {
         WorkflowBuilder workflowBuilder = new WorkflowBuilder();
         TaskFactory taskFactory = new TaskFactory(workflowBuilder);
         Task gatherTest = taskFactory.createGatherTask("test-platform", testPlatform);
         Task gatherTestRepo =
                 taskFactory.createRepoTask(
                         "test-platform-repo", Collections.singletonList(gatherTest));
-        taskFactory.createProvisionTask(gatherTestRepo, composeRepoDir);
+        taskFactory.createProvisionTask(provisionTaskId, gatherTestRepo, composeRepoDir);
         return workflowBuilder.build();
     }
 }

--- a/src/main/java/io/kojan/mbici/workspace/AbstractTmtCommand.java
+++ b/src/main/java/io/kojan/mbici/workspace/AbstractTmtCommand.java
@@ -44,6 +44,7 @@ public abstract class AbstractTmtCommand extends AbstractCommand {
         ShellCommand shell = null;
         if (requiresGuest()) {
             shell = new ShellCommand();
+            shell.setId("test-" + getTestPlan());
             Integer ret = shell.provision();
             if (ret != 0) {
                 return ret;

--- a/src/main/java/io/kojan/mbici/workspace/ShellCommand.java
+++ b/src/main/java/io/kojan/mbici/workspace/ShellCommand.java
@@ -31,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
 
 @Command(
         name = "shell",
@@ -38,6 +39,18 @@ import picocli.CommandLine.Command;
         mixinStandardHelpOptions = true,
         versionProvider = Main.class)
 public class ShellCommand extends AbstractCommand {
+    @Option(
+            names = {"-i", "--id"},
+            description = "Unique identifier of this shell run.")
+    private String id = "shell";
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
 
     private Guest getGuest() {
         ProvisionTaskHandler handler = ProvisionTaskHandler.getInstance();
@@ -67,7 +80,7 @@ public class ShellCommand extends AbstractCommand {
         Path yamlPath = ws.getWorkspaceDir().resolve("mbi.yaml");
         YamlConf yaml = YamlConf.load(yamlPath);
         WorkflowFactory wff = new WorkflowFactory();
-        Workflow wf = wff.createTestWorkflow(yaml.getTestPlatform(), composeRepoDir);
+        Workflow wf = wff.createTestWorkflow(id, yaml.getTestPlatform(), composeRepoDir);
 
         TaskHandlerFactory handlerFactory = new TaskHandlerFactoryImpl(null);
         TaskThrottle throttle =


### PR DESCRIPTION
Previously, multiple tests could interfere with each other because they reused the same identifiers.  By giving each run its own unique ID, tests are now isolated and can be executed in parallel without conflicts.

Closes #41