### PR TITLE
Make link directory optional

### DIFF
--- a/src/main/java/io/kojan/mbici/workspace/ConfigCommand.java
+++ b/src/main/java/io/kojan/mbici/workspace/ConfigCommand.java
@@ -37,7 +37,9 @@ public class ConfigCommand extends AbstractConfigCommand {
     private boolean env;
 
     private void printEnv(String key, Object value) {
-        System.out.println(key + "=\"" + value + "\"");
+        if (value != null) {
+            System.out.println(key + "=\"" + value + "\"");
+        }
     }
 
     private void printHuman(int n, String key, Object value) {

--- a/src/main/java/io/kojan/mbici/workspace/RunCommand.java
+++ b/src/main/java/io/kojan/mbici/workspace/RunCommand.java
@@ -69,7 +69,9 @@ public class RunCommand extends AbstractCommand {
         Files.createDirectories(c.getCacheDir());
         Files.createDirectories(c.getResultDir());
         Files.createDirectories(c.getWorkDir());
-        Files.createDirectories(c.getLinkDir());
+        if (c.getLinkDir() != null) {
+            Files.createDirectories(c.getLinkDir());
+        }
 
         Path yamlPath = ws.getWorkspaceDir().resolve("mbi.yaml");
         YamlConf yaml = YamlConf.load(yamlPath);

--- a/src/main/java/io/kojan/mbici/workspace/ShellCommand.java
+++ b/src/main/java/io/kojan/mbici/workspace/ShellCommand.java
@@ -66,13 +66,7 @@ public class ShellCommand extends AbstractCommand {
         WorkspaceConfig c = ws.getConfig();
         info("Using workspace at " + ws.getWorkspaceDir());
 
-        Path composeRepoDir =
-                Files.readSymbolicLink(c.getLinkDir().resolve("compose")).resolve("repo");
-        if (!Files.isDirectory(composeRepoDir)) {
-            error("Compose is absent");
-            info("You should run the \"mbi run\" command to generate the compose");
-            return 1;
-        }
+        Path composeRepoDir = AbstractTmtCommand.findComposeOrAbort(ws);
 
         Files.createDirectories(c.getTestResultDir());
         Files.createDirectories(c.getWorkDir());

--- a/src/main/java/io/kojan/mbici/workspace/StatusCommand.java
+++ b/src/main/java/io/kojan/mbici/workspace/StatusCommand.java
@@ -22,6 +22,8 @@ import io.kojan.workflow.model.Artifact;
 import io.kojan.workflow.model.Result;
 import io.kojan.workflow.model.TaskOutcome;
 import io.kojan.workflow.model.Workflow;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 import picocli.CommandLine.Command;
@@ -70,14 +72,18 @@ public class StatusCommand extends AbstractCommand {
                 info("  - task: " + result.getTaskId());
                 info("    reason: " + result.getOutcomeReason());
                 info("    logs:");
+                Path taskDir = c.getResultDir().resolve(result.getTaskId()).resolve(result.getId());
+                if (c.getLinkDir() != null) {
+                    Path linkPath = c.getLinkDir().resolve(result.getTaskId());
+                    if (Files.isSymbolicLink(linkPath)
+                            && Files.readSymbolicLink(linkPath).equals(taskDir)) {
+                        taskDir = linkPath;
+                    }
+                }
                 for (Artifact artifact : result.getArtifacts()) {
                     if (artifact.getType().equals(ArtifactType.LOG)
                             || artifact.getType().equals(ArtifactType.CONFIG)) {
-                        info(
-                                "      - "
-                                        + c.getLinkDir()
-                                                .resolve(result.getTaskId())
-                                                .resolve(artifact.getName()));
+                        info("      - " + taskDir.resolve(artifact.getName()));
                     }
                 }
             }

--- a/src/main/java/io/kojan/mbici/workspace/Workspace.java
+++ b/src/main/java/io/kojan/mbici/workspace/Workspace.java
@@ -127,7 +127,7 @@ public class Workspace {
                             WorkspaceConfig::setWorkDir,
                             Path::toString,
                             Path::of),
-                    Attribute.of(
+                    Attribute.ofOptional(
                             "linkDir",
                             WorkspaceConfig::getLinkDir,
                             WorkspaceConfig::setLinkDir,


### PR DESCRIPTION
The runtime no longer requires symlinks in the link directory, since all necessary information is already available in the XML metadata. The link directory is now treated only as a convenience for shorter paths and easier navigation, but workflows and commands work correctly without it.  This makes the runtime simpler, reduces unnecessary dependencies, and gives users more flexibility in how they configure their workspace.

Closes #42