### PR TITLE
Allow reserving container after run for debugging

### DIFF
--- a/src/main/java/io/kojan/mbici/workspace/AbstractTmtCommand.java
+++ b/src/main/java/io/kojan/mbici/workspace/AbstractTmtCommand.java
@@ -41,6 +41,8 @@ public abstract class AbstractTmtCommand extends AbstractCommand {
 
     protected abstract boolean requiresGuest();
 
+    protected abstract boolean reserveSys();
+
     public static Path findComposeOrAbort(Workspace ws) throws IOException, XMLException {
         WorkspaceConfig c = ws.getConfig();
         Workflow wf = Workflow.readFromXML(c.getWorkflowPath());
@@ -141,6 +143,9 @@ public abstract class AbstractTmtCommand extends AbstractCommand {
 
         int ret = new ProcessBuilder(cmd).inheritIO().start().waitFor();
         if (shell != null) {
+            if (reserveSys()) {
+                shell.connect();
+            }
             shell.terminate();
         }
         return ret;

--- a/src/main/java/io/kojan/mbici/workspace/TestCommand.java
+++ b/src/main/java/io/kojan/mbici/workspace/TestCommand.java
@@ -17,6 +17,7 @@ package io.kojan.mbici.workspace;
 
 import io.kojan.mbici.Main;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 @Command(
@@ -29,6 +30,11 @@ public class TestCommand extends AbstractTmtCommand {
     @Parameters(index = "0", description = "Name of tmt test plan to run.")
     private String testPlan;
 
+    @Option(
+            names = {"-r", "--reserve"},
+            description = "Shell into mock container after testing ends.")
+    private boolean reserve;
+
     @Override
     protected String getTestPlan() {
         return testPlan;
@@ -37,5 +43,10 @@ public class TestCommand extends AbstractTmtCommand {
     @Override
     protected boolean requiresGuest() {
         return true;
+    }
+
+    @Override
+    protected boolean reserveSys() {
+        return reserve;
     }
 }

--- a/src/main/java/io/kojan/mbici/workspace/ValidateCommand.java
+++ b/src/main/java/io/kojan/mbici/workspace/ValidateCommand.java
@@ -34,4 +34,9 @@ public class ValidateCommand extends AbstractTmtCommand {
     protected boolean requiresGuest() {
         return false;
     }
+
+    @Override
+    protected boolean reserveSys() {
+        return false;
+    }
 }


### PR DESCRIPTION
When a test finishes, the provisioned container would previously always be destroyed, making it hard to investigate failures.  With this change, the container can be reserved and kept alive after the test ends, so you can shell into it and debug the environment directly.

Closes #44