### PR TITLE
Allow running tests in an existing provision

### DIFF
--- a/src/main/java/io/kojan/mbici/workspace/TestCommand.java
+++ b/src/main/java/io/kojan/mbici/workspace/TestCommand.java
@@ -38,12 +38,17 @@ public class TestCommand extends AbstractTmtCommand {
             description = "Shell into mock container after testing ends.")
     private boolean reserve;
 
+    @Option(
+            names = {"--no-provision"},
+            description = "Connect to existing mock container without provisioning a new one.")
+    private boolean noProvision;
+
     @Override
     public Integer call() throws Exception {
 
         ShellCommand shell = new ShellCommand();
         shell.setId("test-" + testPlan);
-        Integer ret = shell.provision();
+        Integer ret = noProvision ? shell.lookupExistingProvision() : shell.provision();
         if (ret != 0) {
             return ret;
         }
@@ -116,7 +121,9 @@ public class TestCommand extends AbstractTmtCommand {
         if (reserve) {
             shell.connect();
         }
-        shell.terminate();
+        if (!noProvision) {
+            shell.terminate();
+        }
         return tmtRet;
     }
 }


### PR DESCRIPTION
Tests no longer need to always start from a freshly provisioned container.  With this change, they can connect to an already running provision and execute directly inside it.  This makes it easier to iterate quickly when debugging tests, since you can reuse the same environment instead of repeatedly recreating it from scratch.

Closes #45